### PR TITLE
Add option to predict nugget term only

### DIFF
--- a/PUQ/surrogatemethods/hetGP.py
+++ b/PUQ/surrogatemethods/hetGP.py
@@ -170,12 +170,19 @@ def predict(predinfo, fitinfo, x, theta, thetaprime=None,rep_no=None, **kwargs):
     if GP is None:
         # use wrapper class to instantiate trained GP
         GP = hetGPWrapper(fitinfo=fitinfo)
+    
+    # handle kws
+    kws = {}
+    eligible_keys = ['nugs_only','interval','interval_lower','interval_upper']
+    for key in eligible_keys:
+        if key in kwargs.keys():
+            kws[key] = kwargs.get('nugs_only')
 
 
-    preds = GP.predict(x=x,xprime=thetaprime)
+    preds = GP.predict(x=x,xprime=thetaprime,**kws)
     # ensure naming consistency
-    predinfo['mean']   = preds['mean']
-    predinfo['var']    = preds['sd2']
-    predinfo['nugs']   = preds['nugs']
-    predinfo['covmat'] = preds['cov']
+    predinfo['mean']   = preds.get('mean')
+    predinfo['var']    = preds.get('sd2')
+    predinfo['nugs']   = preds.get('nugs')
+    predinfo['covmat'] = preds.get('cov')
     return

--- a/PUQ/surrogatemethods/homGP.py
+++ b/PUQ/surrogatemethods/homGP.py
@@ -127,11 +127,17 @@ def predict(predinfo, fitinfo, x, theta, thetaprime=None, **kwargs):
     if GP is None:
         # use wrapper class to instantiate trained GP
         GP = homGPWrapper(fitinfo=fitinfo)
+    # handle kws
+    kws = {}
+    eligible_keys = ['nugs_only','interval','interval_lower','interval_upper']
+    for key in eligible_keys:
+        if key in kwargs.keys():
+            kws[key] = kwargs.get('nugs_only')
 
 
-    preds = GP.predict(x=x,xprime=thetaprime)
+    preds = GP.predict(x=x,xprime=thetaprime,**kws)
     # ensure naming consistency
-    predinfo['mean']   = preds['mean']
-    predinfo['var']    = preds['sd2']
-    predinfo['nugs']   = preds['nugs']
-    predinfo['covmat'] = preds['cov']
+    predinfo['mean']   = preds.get('mean')
+    predinfo['var']    = preds.get('sd2')
+    predinfo['nugs']   = preds.get('nugs')
+    predinfo['covmat'] = preds.get('cov')

--- a/tests/unit_tests/test_hetGP.py
+++ b/tests/unit_tests/test_hetGP.py
@@ -78,5 +78,22 @@ def test_predict():
     assert np.allclose(test_preds._info['nugs'],preds['nugs'])
     assert np.allclose(test_preds._info['covmat'],preds['cov'])
 
+def test_predict_nugs_only():
+
+    reference_model = hetGP()
+    reference_model.mle(X,Y.flatten())
+
+
+    test_model = emulator(x=X,theta=np.array([0]),f=Y,method='hetGP')
+    test_model.fit()
+
+    # test predictions
+    preds = reference_model.predict(Xgrid,xprime=Xgrid,nugs_only=True)
+
+    test_preds = test_model.predict(x=Xgrid,thetaprime=Xgrid,args=dict(nugs_only=True))
+    for key in ['mean','var','covmat']:
+        assert test_preds._info.get(key) is None
+    assert np.allclose(test_preds._info['nugs'],preds['nugs'])
+
 if __name__ == "__main__":
-    test_predict()
+    test_predict_nugs_only()

--- a/tests/unit_tests/test_homGP.py
+++ b/tests/unit_tests/test_homGP.py
@@ -55,6 +55,23 @@ def test_predict():
     assert np.allclose(test_preds._info['covmat'],preds['cov'])
 
 
+def test_predict_nugs_only():
+
+    reference_model = homGP()
+    reference_model.mle(X,Y.flatten())
+
+
+    test_model = emulator(x=X,theta=np.array([0]),f=Y,method='homGP')
+    test_model.fit()
+
+    # test predictions
+    preds = reference_model.predict(Xgrid,xprime=Xgrid,nugs_only=True)
+
+    test_preds = test_model.predict(x=Xgrid,thetaprime=Xgrid,args=dict(nugs_only=True))
+    for key in ['mean','var','covmat']:
+        assert test_preds._info.get(key) is None
+    assert np.allclose(test_preds._info['nugs'],preds['nugs'])
+    
 def test_matern():
     # test a different covariance type and define some input args
     COVTYPE = "Matern5_2"
@@ -78,5 +95,5 @@ def test_matern():
 
 
 if __name__ == "__main__":
-    test_predict()
+    test_predict_nugs_only()
 


### PR DESCRIPTION
This pull request adds functionality to only predict the noise for a GP. When this option is active, noise prediction is faster, and the `mean`, `var`, and `covmat` attributes of a prediction object are set to `None`