### PR TITLE
Update wrapper

### DIFF
--- a/PUQ/surrogate.py
+++ b/PUQ/surrogate.py
@@ -339,6 +339,9 @@ class emulator(object):
         info = {}
         self.method.predict(info, self._info, x, theta, thetaprime, **argstemp)
         return prediction(info, self)
+    def update(self,x=None,Y=None,**kwargs):
+
+        self.method.update(self._info,x=x,Y=Y,**kwargs)
 
     def acquisition(self, x=None, theta1=None, theta2=None):
         return self.method.acquisition(self._info, x, theta1, theta2)

--- a/PUQ/surrogatemethods/hetGP.py
+++ b/PUQ/surrogatemethods/hetGP.py
@@ -156,7 +156,8 @@ def update(fitinfo, x,Y = None,**kwargs):
     fitinfo: dictionary that contains the fit information for a hetgpy.homGP object
     x: array of new design locations
     Y: new response. If None, then 
-    kwargs: key-value pairs that get passed to hetgpy.homGP.update. Must be one of:
+    kwargs: key-value pairs that get passed to hetgpy.hetGP.update. 
+        Must be one of: ginit, lower, upper, noiseControl, settings, known, maxit, method
     '''
     # validate kwargs
     valid_kws = ('ginit','lower','upper',

--- a/PUQ/surrogatemethods/hetGP.py
+++ b/PUQ/surrogatemethods/hetGP.py
@@ -147,3 +147,32 @@ def predict(predinfo, fitinfo, x, theta, thetaprime=None,rep_no=None, **kwargs):
     predinfo['nugs']   = preds.get('nugs')
     predinfo['covmat'] = preds.get('cov')
     return
+def update(fitinfo, x,Y = None,**kwargs):
+    r'''
+    Update function for homGP
+
+    Parameters
+    ----------
+    fitinfo: dictionary that contains the fit information for a hetgpy.homGP object
+    x: array of new design locations
+    Y: new response. If None, then 
+    kwargs: key-value pairs that get passed to hetgpy.homGP.update. Must be one of:
+    '''
+    # validate kwargs
+    valid_kws = ('ginit','lower','upper',
+                 'noiseControl','settings','known','maxit','method')
+    for kw in kwargs.keys():
+        if kw not in valid_kws:
+            raise ValueError(f"{kw} not found, must be one of {valid_kws}")
+    GP = hetGPWrapper(fitinfo)
+    if Y is None:
+        maxit = 0 # impute mean response and do not update hyperparams
+        Y = GP.predict(x)['mean']
+    else:
+        maxit = kwargs.get('maxit',100)
+    kwargs['maxit'] = maxit
+    GP.update(Xnew=x,Znew=Y,**kwargs)
+    for key in GP.__dict__.keys():
+        fitinfo[key] = GP.get(key)
+    del GP
+    return

--- a/PUQ/surrogatemethods/hetGP.py
+++ b/PUQ/surrogatemethods/hetGP.py
@@ -160,7 +160,7 @@ class hetGPWrapper(hetGP):
 
         # model hyperparameters
         for key in keys_to_transfer:
-            self[key] = fitinfo[key]   
+            setattr(self,key,fitinfo[key])   
 
 def predict(predinfo, fitinfo, x, theta, thetaprime=None,rep_no=None, **kwargs):
     r'''

--- a/PUQ/surrogatemethods/hetGP.py
+++ b/PUQ/surrogatemethods/hetGP.py
@@ -108,29 +108,9 @@ def fit(fitinfo, x, theta, f,
             eps=eps,
             covtype=covtype
     )
-    fitinfo['ll']   = model.get('ll')
-    fitinfo['Delta'] = model.get('Delta')
-    fitinfo['theta'] = model.get('theta')
-    fitinfo['g'] = model.get('g')  
-    fitinfo['k_theta_g'] = model.get('k_theta_g') 
-    fitinfo['theta_g'] = model.get('theta_g')  
-    fitinfo['nmean'] = model.get('nmean')
-    fitinfo['Lambda'] = model.get('Lambda')
-    fitinfo['logN'] = model.get('logN')
-    fitinfo['nu_hat_var'] = model.get('nu_hat_var')
-    fitinfo['nu_hat'] = model.get('nu_hat')
-    fitinfo['Kgi']    = model.get('Kgi')
-    fitinfo['SiNK']   = model.get('SiNK')
-    fitinfo['Ki'] = model.get('Ki') 
-    fitinfo['X0'] = model.get('X0')
-    fitinfo['Z0'] = model.get('Z0')
-    fitinfo['Z']  = model.get('Z')
-    fitinfo['mult'] = model.get('mult')
-    fitinfo['covtype'] = model.get('covtype')
-    fitinfo['beta0'] = model.get('beta0')
-    fitinfo['eps'] = model.get('eps')
-    fitinfo['trendtype'] = model.get('trendtype')
-    fitinfo['is_homGP'] = model.get('is_homGP')
+    for key in model.__dict__.keys():
+        fitinfo[key] = model.get(key) 
+    fitinfo['is_homGP'] = False
     return
     
 class hetGPWrapper(hetGP):
@@ -140,26 +120,7 @@ class hetGPWrapper(hetGP):
 
     '''
     def __init__(self,fitinfo):
-        
-        keys_to_transfer = [
-            'X0','Z0','Z', # data
-            'covtype',     # kernel
-            'theta', 'g', 'beta0','trendtype', # hyperparameters
-            'Lambda', 'Delta', # latent noise
-            'theta_g','k_theta_g', # noise hyperparameters
-            'nu_hat_var', # noise variance
-            'Kgi', # noise covariance inverse
-            'SiNK',
-            'nmean',
-            'logN', 
-            'g', # nugget
-            'Ki', # inverse covariance matrix
-            'eps', # for numeric stability
-            'nu_hat' # output from maximum likelihood
-        ]
-
-        # model hyperparameters
-        for key in keys_to_transfer:
+        for key in fitinfo.keys():
             setattr(self,key,fitinfo[key])   
 
 def predict(predinfo, fitinfo, x, theta, thetaprime=None,rep_no=None, **kwargs):

--- a/PUQ/surrogatemethods/homGP.py
+++ b/PUQ/surrogatemethods/homGP.py
@@ -116,7 +116,7 @@ class homGPWrapper(homGP):
 
         # model hyperparameters
         for key in keys_to_transfer:
-            self[key] = fitinfo[key]
+            setattr(self,key,fitinfo[key])
 
 
 def predict(predinfo, fitinfo, x, theta, thetaprime=None, **kwargs):

--- a/PUQ/surrogatemethods/homGP.py
+++ b/PUQ/surrogatemethods/homGP.py
@@ -79,20 +79,8 @@ def fit(fitinfo, x, theta, f, lower=None, upper=None,
                      eps=eps,
                      settings=settings)
     
-    fitinfo['theta'] = model['theta']
-    fitinfo['g'] = model['g']  
-    fitinfo['nu_hat'] = model['nu_hat']
-    fitinfo['Ki'] = model['Ki']  
-    fitinfo['X0'] = model['X0']
-    fitinfo['Z0'] = model['Z0']
-    fitinfo['Z']  = model['Z']
-    fitinfo['mult'] = model['mult']
-    fitinfo['beta0'] = model['beta0']
-    fitinfo['ll'] = model['ll']
-    fitinfo['covtype'] = model['covtype']
-    fitinfo['nu_hat']  = model['nu_hat']    
-    fitinfo['trendtype'] = model['trendtype']  
-    fitinfo['eps'] = model['eps']  
+    for key in model.__dict__.keys():
+        fitinfo[key] = model.get(key) 
     fitinfo['is_homGP'] = True
     return
 
@@ -104,18 +92,8 @@ class homGPWrapper(homGP):
 
     '''
     def __init__(self,fitinfo):
-        
-        keys_to_transfer = [
-            'X0','Z0','Z', # data
-            'covtype',     # kernel
-            'theta', 'g', 'beta0','trendtype', # hyperparameters
-            'Ki', # inverse covariance matrix
-            'eps', # for numeric stability
-            'nu_hat' # output from maximum likelihood
-        ]
-
         # model hyperparameters
-        for key in keys_to_transfer:
+        for key in fitinfo.keys():
             setattr(self,key,fitinfo[key])
 
 
@@ -141,3 +119,7 @@ def predict(predinfo, fitinfo, x, theta, thetaprime=None, **kwargs):
     predinfo['var']    = preds.get('sd2')
     predinfo['nugs']   = preds.get('nugs')
     predinfo['covmat'] = preds.get('cov')
+
+def update(fitinfo, x):
+
+    return

--- a/PUQ/surrogatemethods/homGP.py
+++ b/PUQ/surrogatemethods/homGP.py
@@ -82,6 +82,7 @@ def fit(fitinfo, x, theta, f, lower=None, upper=None,
     for key in model.__dict__.keys():
         fitinfo[key] = model.get(key) 
     fitinfo['is_homGP'] = True
+    del model
     return
 
 
@@ -119,7 +120,34 @@ def predict(predinfo, fitinfo, x, theta, thetaprime=None, **kwargs):
     predinfo['var']    = preds.get('sd2')
     predinfo['nugs']   = preds.get('nugs')
     predinfo['covmat'] = preds.get('cov')
+    del GP
 
-def update(fitinfo, x):
+def update(fitinfo, x,Y = None,**kwargs):
+    r'''
+    Update function for homGP
 
+    Parameters
+    ----------
+    fitinfo: dictionary that contains the fit information for a hetgpy.homGP object
+    x: array of new design locations
+    Y: new response. If None, then 
+    kwargs: key-value pairs that get passed to hetgpy.homGP.update. Must be one of:
+    '''
+    # validate kwargs
+    valid_kws = ('ginit','lower','upper',
+                 'noiseControl','settings','known','maxit')
+    for kw in kwargs.keys():
+        if kw not in valid_kws:
+            raise ValueError(f"{kw} not found, must be one of {valid_kws}")
+    GP = homGPWrapper(fitinfo)
+    if Y is None:
+        maxit = 0 # impute mean response and do not update hyperparams
+        Y = GP.predict(x)['mean']
+    else:
+        maxit = kwargs.get('maxit',100)
+    kwargs['maxit'] = maxit
+    GP.update(Xnew=x,Znew=Y,**kwargs)
+    for key in GP.__dict__.keys():
+        fitinfo[key] = GP.get(key)
+    del GP
     return

--- a/PUQ/surrogatemethods/homGP.py
+++ b/PUQ/surrogatemethods/homGP.py
@@ -131,7 +131,8 @@ def update(fitinfo, x,Y = None,**kwargs):
     fitinfo: dictionary that contains the fit information for a hetgpy.homGP object
     x: array of new design locations
     Y: new response. If None, then 
-    kwargs: key-value pairs that get passed to hetgpy.homGP.update. Must be one of:
+    kwargs: key-value pairs that get passed to hetgpy.homGP.update. 
+            Must be one of: ginit, lower, upper, noiseControl, settings, known, maxit
     '''
     # validate kwargs
     valid_kws = ('ginit','lower','upper',

--- a/tests/unit_tests/test_hetGP.py
+++ b/tests/unit_tests/test_hetGP.py
@@ -95,5 +95,41 @@ def test_predict_nugs_only():
         assert test_preds._info.get(key) is None
     assert np.allclose(test_preds._info['nugs'],preds['nugs'])
 
+def test_hetGP_update_kriging_believer():
+    reference_model = hetGP()
+    reference_model.mle(X,Y.flatten())
+
+    Xnew = X.mean().reshape(-1,1)
+    Ypred = reference_model.predict(Xnew)['mean']
+    reference_model.update(Xnew,Ypred,maxit=0)
+    
+    test_model = emulator(x=X,theta=np.array([0]),f=Y,
+                          method='hetGP')
+    test_model.fit()
+    test_model.update(Xnew)
+
+    assert test_model._info['ll']    == reference_model['ll']
+    assert test_model._info['theta'] == reference_model['theta']
+    assert test_model._info['g']     == reference_model['g']
+    assert test_model._info['beta0'] == reference_model['beta0']
+
+def test_hetGP_update():
+    reference_model = hetGP()
+    reference_model.mle(X,Y.flatten())
+
+    Xnew = X.mean().reshape(-1,1)
+    Ypred = reference_model.predict(Xnew)['mean']
+    reference_model.update(Xnew,Ypred)
+    
+    test_model = emulator(x=X,theta=np.array([0]),f=Y,
+                          method='hetGP')
+    test_model.fit()
+    test_model.update(x=Xnew,Y=Ypred)
+
+    assert test_model._info['ll']    == reference_model['ll']
+    assert test_model._info['theta'] == reference_model['theta']
+    assert test_model._info['g']     == reference_model['g']
+    assert test_model._info['beta0'] == reference_model['beta0']
+
 if __name__ == "__main__":
-    test_predict_nugs_only()
+    test_hetGP_update_kriging_believer()

--- a/tests/unit_tests/test_homGP.py
+++ b/tests/unit_tests/test_homGP.py
@@ -54,7 +54,6 @@ def test_predict():
     assert np.allclose(test_preds._info['nugs'],preds['nugs'])
     assert np.allclose(test_preds._info['covmat'],preds['cov'])
 
-
 def test_predict_nugs_only():
 
     reference_model = homGP()
@@ -94,6 +93,30 @@ def test_matern():
     assert test_model._info['beta0'] == reference_model['beta0']
 
 
+def test_homGP_update_kriging_believer():
+    reference_model = homGP()
+    reference_model.mle(X,Y.flatten())
+
+    Xnew = X.mean().reshape(-1,1)
+    Ypred = reference_model.predict(Xnew)['mean']
+    reference_model.predict(Xnew,Ypred)
+    reference_model_checkpoint = reference_model.copy()
+    reference_model.update(Xnew,Ypred,maxit=0)
+    
+    test_model = emulator(x=X,theta=np.array([0]),f=Y,
+                          method='homGP')
+    test_model.fit()
+    test_model.update(Xnew)
+
+    assert test_model._info['ll']    == reference_model['ll']
+    assert test_model._info['theta'] == reference_model['theta']
+    assert test_model._info['g']     == reference_model['g']
+    assert test_model._info['beta0'] == reference_model['beta0']
+
+
+#def test_homGP_update_()
+
+
 if __name__ == "__main__":
-    test_predict_nugs_only()
+    test_homGP_update_kriging_believer()
 

--- a/tests/unit_tests/test_homGP.py
+++ b/tests/unit_tests/test_homGP.py
@@ -99,7 +99,6 @@ def test_homGP_update_kriging_believer():
 
     Xnew = X.mean().reshape(-1,1)
     Ypred = reference_model.predict(Xnew)['mean']
-    reference_model.predict(Xnew,Ypred)
     reference_model.update(Xnew,Ypred,maxit=0)
     
     test_model = emulator(x=X,theta=np.array([0]),f=Y,
@@ -118,7 +117,6 @@ def test_homGP_update():
 
     Xnew = X.mean().reshape(-1,1)
     Ypred = reference_model.predict(Xnew)['mean']
-    reference_model.predict(Xnew,Ypred)
     reference_model.update(Xnew,Ypred)
     
     test_model = emulator(x=X,theta=np.array([0]),f=Y,

--- a/tests/unit_tests/test_homGP.py
+++ b/tests/unit_tests/test_homGP.py
@@ -100,7 +100,6 @@ def test_homGP_update_kriging_believer():
     Xnew = X.mean().reshape(-1,1)
     Ypred = reference_model.predict(Xnew)['mean']
     reference_model.predict(Xnew,Ypred)
-    reference_model_checkpoint = reference_model.copy()
     reference_model.update(Xnew,Ypred,maxit=0)
     
     test_model = emulator(x=X,theta=np.array([0]),f=Y,
@@ -113,10 +112,26 @@ def test_homGP_update_kriging_believer():
     assert test_model._info['g']     == reference_model['g']
     assert test_model._info['beta0'] == reference_model['beta0']
 
+def test_homGP_update():
+    reference_model = homGP()
+    reference_model.mle(X,Y.flatten())
 
-#def test_homGP_update_()
+    Xnew = X.mean().reshape(-1,1)
+    Ypred = reference_model.predict(Xnew)['mean']
+    reference_model.predict(Xnew,Ypred)
+    reference_model.update(Xnew,Ypred)
+    
+    test_model = emulator(x=X,theta=np.array([0]),f=Y,
+                          method='homGP')
+    test_model.fit()
+    test_model.update(x=Xnew,Y=Ypred)
+
+    assert test_model._info['ll']    == reference_model['ll']
+    assert test_model._info['theta'] == reference_model['theta']
+    assert test_model._info['g']     == reference_model['g']
+    assert test_model._info['beta0'] == reference_model['beta0']
 
 
 if __name__ == "__main__":
-    test_homGP_update_kriging_believer()
+    test_homGP_update()
 


### PR DESCRIPTION
This adds the `update` functions to the emulator modules. Also adds more unit tests for homGP and hetGP to test the updating functionality

This pull request also abstracts the `homGPwrapper` and `hetGPwrapper` classes in `homGP.py` and `hetGP.py` to utilize the `setattr` functions to copy the entire object over from a homGP/hetGP object, rather than having to list out all the hyperparameters and functions

Also adds an `update` function to `surrogate.py` so that the emulator can call an update function.

This should close #20 item 1