### PR TITLE
Generalize GP wrapper function

### DIFF
--- a/PUQ/surrogatemethods/hetGP.py
+++ b/PUQ/surrogatemethods/hetGP.py
@@ -1,5 +1,6 @@
 import numpy as np
-from hetgpy import hetGP
+from hetgpy import hetGP, homGP
+from PUQ.surrogatemethods.homGP import GPWrapper
 
 ###############################################################################
 ## Heterogeneous GP with all options for the fit
@@ -112,18 +113,10 @@ def fit(fitinfo, x, theta, f,
     )
     for key in model.__dict__.keys():
         fitinfo[key] = model.get(key) 
-    fitinfo['is_homGP'] = False
+    fitinfo['is_homGP'] = isinstance(model,homGP)
     return
     
-class hetGPWrapper(hetGP):
-    '''
-    A class that converts the information in fitinfo (from the fit and predict methods) to a class so
-    it can be used to make predictions with hetgpy.hetGP
-
-    '''
-    def __init__(self,fitinfo):
-        for key in fitinfo.keys():
-            setattr(self,key,fitinfo[key])   
+ 
 
 def predict(predinfo, fitinfo, x, theta, thetaprime=None,rep_no=None, **kwargs):
     r'''
@@ -132,14 +125,14 @@ def predict(predinfo, fitinfo, x, theta, thetaprime=None,rep_no=None, **kwargs):
     GP = fitinfo.get('model')
     if GP is None:
         # use wrapper class to instantiate trained GP
-        GP = hetGPWrapper(fitinfo=fitinfo)
+        GP = GPWrapper(fitinfo=fitinfo)
     
     # handle kws
     kws = {}
     eligible_keys = ['nugs_only','interval','interval_lower','interval_upper']
     for key in eligible_keys:
         if key in kwargs.keys():
-            kws[key] = kwargs.get('nugs_only')
+            kws[key] = kwargs.get(key)
 
 
     preds = GP.predict(x=x,xprime=thetaprime,**kws)
@@ -151,11 +144,11 @@ def predict(predinfo, fitinfo, x, theta, thetaprime=None,rep_no=None, **kwargs):
     return
 def update(fitinfo, x,Y = None,**kwargs):
     r'''
-    Update function for homGP
+    Update function for hetGP
 
     Parameters
     ----------
-    fitinfo: dictionary that contains the fit information for a hetgpy.homGP object
+    fitinfo: dictionary that contains the fit information for a hetgpy.hetGP object
     x: array of new design locations
     Y: new response. If None, then 
     kwargs: key-value pairs that get passed to hetgpy.hetGP.update. 
@@ -167,7 +160,7 @@ def update(fitinfo, x,Y = None,**kwargs):
     for kw in kwargs.keys():
         if kw not in valid_kws:
             raise ValueError(f"{kw} not found, must be one of {valid_kws}")
-    GP = hetGPWrapper(fitinfo)
+    GP = GPWrapper(fitinfo)
     if Y is None:
         maxit = 0 # impute mean response and do not update hyperparams
         Y = GP.predict(x)['mean']

--- a/PUQ/surrogatemethods/homGP.py
+++ b/PUQ/surrogatemethods/homGP.py
@@ -1,5 +1,5 @@
 import numpy as np
-from hetgpy import homGP
+from hetgpy import homGP, hetGP
 from hetgpy.auto_bounds import auto_bounds
 from hetgpy.find_reps import find_reps
 
@@ -87,15 +87,25 @@ def fit(fitinfo, x, theta, f, lower=None, upper=None,
 
 
 class homGPWrapper(homGP):
-    '''
-    A class that converts the information in fitinfo (from the fit and predict methods) to a class so
-    it can be used to make predictions with hetgpy.homGP
-
-    '''
     def __init__(self,fitinfo):
-        # model hyperparameters
         for key in fitinfo.keys():
             setattr(self,key,fitinfo[key])
+class hetGPWrapper(hetGP):
+     def __init__(self,fitinfo):
+        for key in fitinfo.keys():
+            setattr(self,key,fitinfo[key])
+
+def GPWrapper(fitinfo):
+    '''
+    A method that converts the information in fitinfo (from the fit and predict methods) to a class so
+    it can be used to make predictions with hetgpy.homGP or hetgpy.hetGP
+
+    '''
+    if fitinfo['is_homGP']:
+        return homGPWrapper(fitinfo)
+    else:
+        return hetGPWrapper(fitinfo)
+
 
 
 def predict(predinfo, fitinfo, x, theta, thetaprime=None, **kwargs):
@@ -124,7 +134,7 @@ def predict(predinfo, fitinfo, x, theta, thetaprime=None, **kwargs):
     GP = fitinfo.get('model')
     if GP is None:
         # use wrapper class to instantiate trained GP
-        GP = homGPWrapper(fitinfo=fitinfo)
+        GP = GPWrapper(fitinfo=fitinfo)
     # handle kws
     kws = {}
     eligible_keys = ['nugs_only','interval','interval_lower','interval_upper']
@@ -163,7 +173,7 @@ def update(fitinfo, x,Y = None,**kwargs):
     for kw in kwargs.keys():
         if kw not in valid_kws:
             raise ValueError(f"{kw} not found, must be one of {valid_kws}")
-    GP = homGPWrapper(fitinfo)
+    GP = GPWrapper(fitinfo)
     if Y is None:
         maxit = 0 # impute mean response and do not update hyperparams
         Y = GP.predict(x)['mean']

--- a/tests/unit_tests/test_hetGP.py
+++ b/tests/unit_tests/test_hetGP.py
@@ -131,5 +131,18 @@ def test_hetGP_update():
     assert test_model._info['g']     == reference_model['g']
     assert test_model._info['beta0'] == reference_model['beta0']
 
+
+def test_conversion_to_homGP():
+    # should return homoskedastic GP
+    X = np.linspace(0,1,20).reshape(-1,1)
+    Y = X
+    model = emulator(x=X,theta=np.array([0]),f=Y,
+                          method='hetGP')
+    Xp = np.linspace(X.min(),X.max(),100).reshape(-1,1)
+    preds = model.predict(Xp)
+    assert model._info['is_homGP']
+    assert model._info.get('Delta') is None
+    assert np.unique(preds._info['nugs']).shape[0] == 1
+
 if __name__ == "__main__":
-    test_hetGP_update_kriging_believer()
+    test_conversion_to_homGP()


### PR DESCRIPTION
This pull request should close #23 by doing the following:

* When a `hetGP` emulator is called, but a homoskedastic
* To avoid a bunch of if-else statements in the emulator `fit` and `predict` methods, I generalized the `homGPWrapper` and `hetGPWrapper` classes to instead get called by a parent `GPWrapper` function which checks whether `fitinfo["is_homGP"]` is True or False and returns the corresponding wrapper class.
* Also updated `PUQ/surrogatemethods/hetGP.py` at line 116 to set `fitinfo["is_homGP"]` based on the result of `isinstance(model,homGP)` rather than always returning `False`

I also ran `examples/Example4/emulator_check.py` and confirmed the code runs as expected (i.e. does not throw a KeyError resulting from trying to run `hetGP.predict`). I also added a test in `tests/unit_tests/test_hetGP.py` that checks that for a simple example (an identity relationship between X and Y) where a `homGP` returns a higher likelihood that the underlying emulator `fitinfo` is updated to look like a `homGP` (in that it does not learn pointwise noise variance and returns one unique nugget term)